### PR TITLE
Fix Animmal-sniffer errors in maven package process

### DIFF
--- a/src/main/java/org/waarp/common/filemonitor/FileMonitor.java
+++ b/src/main/java/org/waarp/common/filemonitor/FileMonitor.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -353,8 +354,8 @@ public class FileMonitor {
         ConcurrentHashMap<String, FileItem> newFileItems =
                 new ConcurrentHashMap<String, FileMonitor.FileItem>();
         if (!lastFileItems.isEmpty()) {
-            removedFileItems = lastFileItems.keySet();
-            removedFileItems.removeAll(fileItems.keySet());
+            removedFileItems = ((Map) lastFileItems).keySet();
+            removedFileItems.removeAll(((Map) fileItems).keySet());
             for (Entry<String, FileItem> key : fileItems.entrySet()) {
                 if (!key.getValue().isStrictlySame(lastFileItems.get(key.getKey()))) {
                     newFileItems.put(key.getKey(), key.getValue());


### PR DESCRIPTION
Java 1.8 changed the signature of `ConcurrentHashMap.keySet()` from

    Set<K> keySet()

to
    ConcurrentHashMap.KeySetView<K,V> keySet()

When compiled with java 1.8, it breaks Maven's animal-sniffer-plugin,
even cross-compiling with `-source 1.7 -target 1.7`.

In this case, we were interested in having a `Set<String>` value,
so casting the `ConcurentHashMap` object to the `Map` interface before
calling keyset() solves the compatibility with java 1.7 (and java 1.6) issues.