### PR TITLE
Fixes E_CONNRESET errors shown by FTP clients in Waarp Gateway FTP

### DIFF
--- a/src/main/java/org/waarp/common/utility/WaarpNettyUtil.java
+++ b/src/main/java/org/waarp/common/utility/WaarpNettyUtil.java
@@ -49,7 +49,6 @@ public class WaarpNettyUtil {
         bootstrap.option(ChannelOption.TCP_NODELAY, true);
         bootstrap.option(ChannelOption.SO_REUSEADDR, true);
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
-        bootstrap.option(ChannelOption.SO_LINGER, 0);
         bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout);
         bootstrap.option(ChannelOption.SO_RCVBUF, 1048576);
         bootstrap.option(ChannelOption.SO_SNDBUF, 1048576);
@@ -72,11 +71,9 @@ public class WaarpNettyUtil {
         bootstrap.group(groupBoss, groupWorker);
         bootstrap.option(ChannelOption.TCP_NODELAY, true);
         bootstrap.option(ChannelOption.SO_REUSEADDR, true);
-        bootstrap.option(ChannelOption.SO_LINGER, 0);
         bootstrap.childOption(ChannelOption.TCP_NODELAY, true);
         bootstrap.childOption(ChannelOption.SO_REUSEADDR, true);
         bootstrap.childOption(ChannelOption.SO_KEEPALIVE, true);
-        bootstrap.childOption(ChannelOption.SO_LINGER, 0);
         bootstrap.childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout);
         bootstrap.childOption(ChannelOption.SO_RCVBUF, 1048576);
         bootstrap.childOption(ChannelOption.SO_SNDBUF, 1048576);


### PR DESCRIPTION
The use of the TCP socket option SO_LINGER causes the clients to receive RST packets
instead of FIN when Waarp Gateway FTP closes a connection. This is considered anormal
behaviour and some clients refuse to shown the list of files (e.g. Filezilla, Firefox, etc.).

Fixes Waarp/WaarpFtp#37
