### PR TITLE
Makes it possible to parse a Json String into an ObjectNode without ignoring Json parse errors

### DIFF
--- a/src/main/java/org/waarp/common/json/JsonHandler.java
+++ b/src/main/java/org/waarp/common/json/JsonHandler.java
@@ -74,7 +74,28 @@ public class JsonHandler {
     }
 
     /**
+     * Parses a string representation of a JSON object and returns 
+     * an ObjectNode.
+     * JSON Processing exceptions are kept.
      * 
+     * @param value
+     * @return the objectNode or null if an error occurs
+     * @throws JsonProcessingException
+     */
+    public static ObjectNode getFromStringExc(String value) throws JsonProcessingException {
+        try {
+            return (ObjectNode) mapper.readTree(value);
+        } catch (JsonProcessingException e) {
+            throw e;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Parses a string representation of a JSON object and returns 
+     * an ObjectNode, swallowing any processing exception.
+     *
      * @param value
      * @return the objectNode or null if an error occurs
      */

--- a/src/test/java/org/waarp/common/json/JsonHandlerTest.java
+++ b/src/test/java/org/waarp/common/json/JsonHandlerTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -112,4 +113,17 @@ public class JsonHandlerTest {
         assertTrue(map != null);
     }
 
+    @Test
+    public void testGetFromStringBadFormat() {
+        String badFormat = "{\"foo\":\"bar\",\"baz\"";
+
+        assertNull("It should be null", JsonHandler.getFromString(badFormat));
+    }
+
+    @Test(expected = JsonProcessingException.class)
+    public void testGetFromStringExcBadFormat() throws JsonProcessingException {
+        String badFormat = "{\"foo\":\"bar\",\"baz\"";
+        
+        JsonHandler.getFromStringExc(badFormat);
+    }
 }


### PR DESCRIPTION
needed for Waarp/WaarpGatewayKernel#39