### PR TITLE
Regexes for filewatchers now match the whole path

### DIFF
--- a/src/main/java/org/waarp/common/filemonitor/RegexFileFilter.java
+++ b/src/main/java/org/waarp/common/filemonitor/RegexFileFilter.java
@@ -54,7 +54,7 @@ public class RegexFileFilter implements FileFilter {
     public boolean accept(File pathname) {
         if (pathname.isFile()) {
             if (pattern != null) {
-                return pattern.matcher(pathname.getName()).matches()
+                return pattern.matcher(pathname.getPath()).matches()
                         && (minimalSize == 0 || pathname.length() >= minimalSize);
             }
             return minimalSize == 0 || pathname.length() >= minimalSize;


### PR DESCRIPTION
The test was just done on the basename, which prevented filtering on the
fullpath in case the watcher is set to recursive.